### PR TITLE
Input Fixes

### DIFF
--- a/Aquarius.sv
+++ b/Aquarius.sv
@@ -498,8 +498,8 @@ assign AUDIO_R = {audio_data, 6'd0};
 
 wire [7:0] pad0, pad1;
 
-pad pad_0(.joy_in(joystick_0[9:0]), .pad_out(pad0 | kbd_pad0));
-pad pad_1(.joy_in(joystick_1[9:0]), .pad_out(pad1 | kbd_pad1));
+pad pad_0(.joy_in(joystick_0[9:0] | kbd_pad0), .pad_out(pad0));
+pad pad_1(.joy_in(joystick_1[9:0] | kbd_pad1), .pad_out(pad1));
 
 // include keyboard decoder
 wire [7:0] key_value; // Pla1 <-> PS2_to_matrix

--- a/rtl/ym2149.sv
+++ b/rtl/ym2149.sv
@@ -112,8 +112,8 @@ always_comb begin
 			11: dout = ymreg[11];
 			12: dout = ymreg[12];
 			13: dout = ymreg[13][3:0];
-			14: dout = ymreg[7][6] ? ymreg[14] : IOA_in;
-			15: dout = ymreg[7][7] ? ymreg[15] : IOB_in;
+			14: dout = ymreg[7][6] ? ymreg[14] | IOA_in: IOA_in;
+			15: dout = ymreg[7][7] ? ymreg[15] | IOB_in: IOB_in;
 		endcase
 	end
 end


### PR DESCRIPTION
Fixed Keyboard cursor keys not being read properly.
Fixed issue with games/software trying to read controller(s) without first initializing the AY-3-9810 PortA/B